### PR TITLE
Add ExceptionHandlerMiddleware tests

### DIFF
--- a/Covid19.Microservices.sln.sln
+++ b/Covid19.Microservices.sln.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Covid19.LocationService", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Covid19.IndividualLabsService", "Covid19.IndividualLabsService\Covid19.IndividualLabsService.csproj", "{4D53C323-61AA-4CDE-90BB-9EAD5141D12F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Covid19.Shared.Tests", "Covid19.Shared.Tests\Covid19.Shared.Tests.csproj", "{F5879B2F-57F7-49ED-B29C-A997C3587D52}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +41,10 @@ Global
 		{4D53C323-61AA-4CDE-90BB-9EAD5141D12F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4D53C323-61AA-4CDE-90BB-9EAD5141D12F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4D53C323-61AA-4CDE-90BB-9EAD5141D12F}.Release|Any CPU.Build.0 = Release|Any CPU
+                {F5879B2F-57F7-49ED-B29C-A997C3587D52}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {F5879B2F-57F7-49ED-B29C-A997C3587D52}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {F5879B2F-57F7-49ED-B29C-A997C3587D52}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {F5879B2F-57F7-49ED-B29C-A997C3587D52}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Covid19.Shared.Tests/Covid19.Shared.Tests.csproj
+++ b/Covid19.Shared.Tests/Covid19.Shared.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.2" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.4" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Covid19.Shared\Covid19.Shared.csproj" />
+  </ItemGroup>
+</Project>

--- a/Covid19.Shared.Tests/Tests/ExceptionHandlerMiddlewareTests.cs
+++ b/Covid19.Shared.Tests/Tests/ExceptionHandlerMiddlewareTests.cs
@@ -1,0 +1,52 @@
+using Covid19.Shared.Exceptions;
+using Covid19.Shared.Middleware;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using System.Net;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Covid19.Shared.Tests
+{
+    public class ExceptionHandlerMiddlewareTests
+    {
+        [Fact]
+        public async Task BadRequestException_Returns_BadRequest_With_Message()
+        {
+            var builder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseCustomExceptionHandler();
+                    app.Run(_ => throw new BadRequestException("bad request"));
+                });
+
+            using var server = new TestServer(builder);
+            using var client = server.CreateClient();
+
+            var response = await client.GetAsync("/");
+            var body = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.Equal("bad request", body);
+        }
+
+        [Fact]
+        public async Task NotFoundException_Returns_NotFound()
+        {
+            var builder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseCustomExceptionHandler();
+                    app.Run(_ => throw new NotFoundException("Entity", 1));
+                });
+
+            using var server = new TestServer(builder);
+            using var client = server.CreateClient();
+
+            var response = await client.GetAsync("/");
+
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add xUnit test project `Covid19.Shared.Tests`
- test that `BadRequestException` returns HTTP 400 and message content
- test that `NotFoundException` returns HTTP 404
- include new project in solution

## Testing
- `dotnet test Covid19.Shared.Tests/Covid19.Shared.Tests.csproj -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684afc52977083249d6d9d84f03c0166