### PR TITLE
Fix typo in IndividualController comment

### DIFF
--- a/Covid19.IndividualService/Controllers/IndividualController.cs
+++ b/Covid19.IndividualService/Controllers/IndividualController.cs
@@ -44,7 +44,7 @@ namespace Covid19.IndividualService.Controllers
         }
 
         /// <summary>
-        /// An enpoint to return individual booked tests based on emailaddress and mobile number
+        /// An endpoint to return individual booked tests based on emailaddress and mobile number
         /// </summary>
         /// <param name="emailAddress"></param>
         /// <param name="mobileNumber"></param>


### PR DESCRIPTION
## Summary
- correct a typo in IndividualController

## Testing
- `dotnet build Covid19.Microservices.sln.sln` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_684afc51bf2083249c1f6b944ada8aee