### PR TITLE
Fix namespace references in LocationService

### DIFF
--- a/Covid19.LocationService/Core/Contracts/Persistence/ILocationRepository.cs
+++ b/Covid19.LocationService/Core/Contracts/Persistence/ILocationRepository.cs
@@ -1,4 +1,4 @@
-﻿using Covid19.IndividualService.Domain.Entities;
+﻿using Covid19.LocationService.Domain.Entities;
 
 namespace Covid19.LocationService.Core.Contracts.Persistence
 {

--- a/Covid19.LocationService/Core/Profiles/MappingProfiles.cs
+++ b/Covid19.LocationService/Core/Profiles/MappingProfiles.cs
@@ -1,5 +1,5 @@
 ﻿using AutoMapper;
-using Covid19.IndividualService.Domain.Entities;
+using Covid19.LocationService.Domain.Entities;
 using Covid19.LocationService.Core.Dto;
 using Covid19.LocationService.Core.Features.Locations.Queries.GetLocationsByIds;
 using static System.Runtime.InteropServices.JavaScript.JSType;

--- a/Covid19.LocationService/Domain/Entities/Location.cs
+++ b/Covid19.LocationService/Domain/Entities/Location.cs
@@ -1,4 +1,4 @@
-﻿namespace Covid19.IndividualService.Domain.Entities
+﻿namespace Covid19.LocationService.Domain.Entities
 {
     public class Location
     {

--- a/Covid19.LocationService/Persistence/LocationDbContext.cs
+++ b/Covid19.LocationService/Persistence/LocationDbContext.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
-using Covid19.IndividualService.Domain.Entities;
+using Covid19.LocationService.Domain.Entities;
 using Covid19.LocationService.Domain.Common;
 
 namespace Covid19.LocationService.Persistence

--- a/Covid19.LocationService/Persistence/Repository/LocationRepository.cs
+++ b/Covid19.LocationService/Persistence/Repository/LocationRepository.cs
@@ -1,4 +1,4 @@
-﻿using Covid19.IndividualService.Domain.Entities;
+﻿using Covid19.LocationService.Domain.Entities;
 using Covid19.LocationService.Core.Contracts.Persistence;
 
 namespace Covid19.LocationService.Persistence.Repository

--- a/Covid19.LocationService/Persistence/Repository/PrepDb.cs
+++ b/Covid19.LocationService/Persistence/Repository/PrepDb.cs
@@ -1,4 +1,4 @@
-﻿using Covid19.IndividualService.Domain.Entities;
+﻿using Covid19.LocationService.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 
 namespace Covid19.LocationService.Persistence.Repository


### PR DESCRIPTION
## Summary
- update namespace for `Location` entity
- update usings to new namespace across LocationService

## Testing
- `dotnet build Covid19.LocationService/Covid19.LocationService.csproj -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684afc50fbfc83249daf0d089e72d0cf