### PR TITLE
Fix typo in allocation validator message

### DIFF
--- a/Covid19.AdministratorService/Core/Features/Administrators/Command/AllocateBookingSpace/AllocateBookingSpaceValidator.cs
+++ b/Covid19.AdministratorService/Core/Features/Administrators/Command/AllocateBookingSpace/AllocateBookingSpaceValidator.cs
@@ -36,7 +36,7 @@ namespace Covid19.AdministratorService.Core.Features.Administrators.Command.Allo
 
             RuleFor(e => e)
             .MustAsync(DoesAllocatedBookingExist)
-            .WithMessage("Booking has been allocated for the specifed location at the specified date.");
+            .WithMessage("Booking has been allocated for the specified location at the specified date.");
 
         }
 


### PR DESCRIPTION
## Summary
- fix typo in AllocateBookingSpaceValidator message

## Testing
- `dotnet test Covid19.Microservices.sln.sln` *(fails: `dotnet` not found)*

------